### PR TITLE
Configure Jekyll action to trigger only on README.md changes

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -5,6 +5,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+    paths: ["README.md"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Prevents unnecessary deploys when other files are modified.

## Changes
- Add paths filter to Jekyll GitHub Pages workflow to trigger only on README.md changes