### PR TITLE
docs: improve CLAUDE.md for clarity and accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Agents guidance
+# AGENTS.md
 
-This file provides guidance to AI agents when working with code in this repository.
+> **Note:** `CLAUDE.md` is a symlink to `AGENTS.md`. Edit `AGENTS.md` to change this content.
 
 ## Project Overview
 
@@ -8,70 +8,44 @@ Minimal template for Obsidian plugins using Bun as the build tool and runtime.
 
 ## Development Commands
 
-### Setup
-
 ```bash
-bun install
-```
-
-### Build and Development
-
-```bash
-bun run dev     # Watch mode with auto-rebuild
-bun run build   # Production build (runs check first)
-```
-
-### Code Quality
-
-```bash
-bun run check         # Run all checks (typecheck + lint + format check)
-bun run typecheck     # TypeScript type checking only
-bun run lint          # Biome linting and markdownlint
-bun run lint:fix      # Auto-fix linting issues
-bun run format        # Format code with Biome
-bun run format:check  # Check formatting without changes
-```
-
-### Versioning
-
-```bash
-bun run version  # Update manifest.json and versions.json from package.json version
+bun install              # Install dependencies
+bun run dev              # Watch mode with auto-rebuild
+bun run build            # Production build (runs check first)
+bun run check            # Run all checks (typecheck + lint + format check)
+bun run typecheck        # TypeScript type checking only
+bun run lint             # Biome linting and markdownlint
+bun run lint:fix         # Auto-fix linting issues
+bun run format           # Format code with Biome
+bun run format:check     # Check formatting without changes
+bun run version          # Sync package.json version → manifest.json + versions.json
 ```
 
 ## Architecture
 
 ### Build System
 
-- **Build script**: [build.ts](build.ts) uses Bun's native bundler
-- **Entry point**: [src/main.ts](src/main.ts)
-- **Output**: `dist/main.js` (CommonJS format)
-- **Externals**: `obsidian` and `electron` are marked as external dependencies
-- Watch mode available via `--watch` flag
+- **Build script**: `build.ts` uses Bun's native bundler
+- **Entry point**: `src/main.ts`
+- **Output**: `./main.js` (CommonJS format, minified in production)
+- **Externals**: `obsidian` and `electron` are not bundled
+- `bun run build` runs `check` before building
 
 ### Plugin Structure
 
-- **Main class**: `ExamplePlugin` extends `Plugin` with type-safe settings and `ExampleSettingTab` for UI configuration
-
-### Configuration Files
-
-- **[manifest.json](manifest.json)**: Obsidian plugin metadata
-- **[versions.json](versions.json)**: Maps plugin versions to minimum Obsidian versions
-- **[tsconfig.json](tsconfig.json)**: TypeScript compiler options (ES2022, noEmit, strict mode)
-- **[biome.json](biome.json)**: Linting and formatting configuration
+`ExamplePlugin` in `src/main.ts` extends Obsidian's `Plugin` class with type-safe settings (`PluginSettings`) and `ExampleSettingTab` for UI configuration.
 
 ### Version Management
 
-The [version-bump.ts](version-bump.ts) script syncs `package.json` version to `manifest.json` and `versions.json`
+`version-bump.ts` reads the version from `package.json` (via `process.env.npm_package_version`) and syncs it to `manifest.json` and `versions.json`. Must be run as `bun run version`, not directly, so the env var is populated.
 
-## Release Process
+### Release Process
 
-Tag and push to trigger GitHub Actions release:
+Tag and push to trigger the GitHub Actions release workflow:
 
 ```bash
 git tag -a 1.0.0 -m "Release 1.0.0"
 git push origin 1.0.0
 ```
 
-## TypeScript Configuration
-
-See tsconfig.json for target ES2022, bundler module resolution, strict mode, and noEmit configuration.
+The workflow builds the plugin and uploads `main.js` and `manifest.json` as release assets.


### PR DESCRIPTION
## Summary

- Consolidate development commands into a single code block for easier scanning
- Replace Markdown link references with inline code (better for LLM context)
- Add details about version-bump env var requirement and release workflow assets
- Document the CLAUDE.md → AGENTS.md symlink relationship
- Remove Configuration Files and TypeScript Configuration sections (redundant)

## Test plan

- [x] `bunx markdownlint AGENTS.md` passes
- [x] `bunx prettier --check AGENTS.md` passes
- [x] `CLAUDE.md` symlink reads correctly