### PR TITLE
Add repository settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+_extends: .github
+
+repository:
+  name: obsidian-plugin-template
+  description: "Minimal template for Obsidian plugins using Bun"
+  homepage: https://philoserf.github.io/obsidian-plugin-template/
+  is_template: true


### PR DESCRIPTION
Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).

This config extends the base settings from `philoserf/.github` and includes repo-specific metadata and overrides.

Settings are applied automatically when the Settings app is installed and this PR is merged.