### PR TITLE
chore: use latest biome schema and pin lockfile versions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "obsidian-plugin-template",
       "devDependencies": {
-        "@biomejs/biome": "latest",
-        "@types/bun": "latest",
-        "@types/node": "latest",
-        "obsidian": "latest",
-        "typescript": "latest",
+        "@biomejs/biome": "^2.4.3",
+        "@types/bun": "^1.3.9",
+        "@types/node": "^25.3.0",
+        "obsidian": "^1.12.2",
+        "typescript": "^5.9.3",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Update `biome.json` schema URL from pinned `2.4.3` to `latest`
- Update `bun.lock` to reflect pinned `^` versions in devDependencies

## Test plan

- [x] `bun run check` passes (typecheck + biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)