### PR TITLE
fix: version-bump trailing newlines, validate redundancy

### DIFF
--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -32,16 +32,6 @@ try {
   errors++;
 }
 
-// Run TypeScript type checking
-console.log("\n📝 Type checking...");
-const typecheckResult = await $`bun run typecheck`.nothrow();
-if (typecheckResult.exitCode === 0) {
-  console.log("✓ Type checking passed");
-} else {
-  console.error("✗ Type checking failed");
-  errors++;
-}
-
 // Run checks
 console.log("\n🔧 Checking code quality...");
 const checkResult = await $`bun run check`.nothrow();
@@ -54,7 +44,7 @@ if (checkResult.exitCode === 0) {
 
 // Build the plugin
 console.log("\n📦 Building plugin...");
-const buildResult = await $`bun run build`.nothrow();
+const buildResult = await $`bun run build.ts`.nothrow();
 if (buildResult.exitCode === 0) {
   console.log("✓ Build successful");
 

--- a/version-bump.ts
+++ b/version-bump.ts
@@ -14,11 +14,11 @@ if (!targetVersion) {
 const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 const { minAppVersion } = manifest;
 manifest.version = targetVersion;
-writeFileSync("manifest.json", JSON.stringify(manifest, null, 2));
+writeFileSync("manifest.json", `${JSON.stringify(manifest, null, 2)}\n`);
 
 // Update versions.json
 const versions = JSON.parse(readFileSync("versions.json", "utf8"));
 versions[targetVersion] = minAppVersion;
-writeFileSync("versions.json", JSON.stringify(versions, null, 2));
+writeFileSync("versions.json", `${JSON.stringify(versions, null, 2)}\n`);
 
 console.log(`Updated to version ${targetVersion}`);


### PR DESCRIPTION
## Summary
- version-bump.ts: append trailing newline to JSON output
- validate-plugin.ts: remove redundant typecheck step, call build directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)